### PR TITLE
hongbo/improvements

### DIFF
--- a/Agents.mbt.md
+++ b/Agents.mbt.md
@@ -848,12 +848,7 @@ pub(open) trait Extendable {}
 9. Don't forget @package prefix when calling functions from other packages
 10. Don't use ++ or -- (not supported), use `i = i + 1` or  `i += 1`
 11. **Don't add explicit `try` for error-raising functions** - errors propagate automatically (unlike Swift)
-
-## Legacy Note
-
-**Older code may use**:
-- `function_name!(...)` for raising functions. This is deprecated; call without `!`.
-- `function_name(...)?` for raising functions. This is deprecated; use `try? function_name(...)` instead, the expression is of type `Result[_]`.
+12. **Legacy syntax**: Older code may use `function_name!(...)` or `function_name(...)?` - these are deprecated; use normal calls and `try?` for Result conversion
 
 
 # MoonBit Build System - Essential Guide

--- a/Agents.mbt.md
+++ b/Agents.mbt.md
@@ -546,7 +546,7 @@ test "functional for loop" {
   inspect(sum_result, content="55")
 
   // special form with condition and state update in the `for` header
-  let sum_result2 : Int = for i = 0, sum = 0; i <= 100; i = i + 1, sum = sum + i {
+  let sum_result2 : Int = for i = 0, sum = 0; i <= 10; i = i + 1, sum = sum + i {
 
   } else {
     sum
@@ -1155,7 +1155,7 @@ The MoonBit code in docstring will be type checked and tested automatically.
 
 ## MoonBit Package `README` Generation Guide
 
-- Output `README.mbt.md` in the package directory; `*.mbt.md` files including runnable MoonBit `test { ... }` blocks will be tested by `moon test`, and symlink it to `README.md` to produce verifiable `README.md` filde.
+- Output `README.mbt.md` in the package directory; `*.mbt.md` files including runnable MoonBit `test { ... }` blocks will be tested by `moon test`, and symlink it to `README.md` to produce verifiable `README.md` file.
 - DON'T duplicate definitions in `*.mbt.md` files wrapped in MoonBit snippets, they are REAL code that shadow the original definitions
 - Aim to cover ≥70% of the public API with concise sections and examples.
 - Use black‑box tests: call via `@package.fn`. The package name used to be the same as the directory name.

--- a/Agents.mbt.md
+++ b/Agents.mbt.md
@@ -411,6 +411,26 @@ fn sum_tree(tree : Tree[Int]) -> Int {
 }
 ```
 
+## Common Derivable Traits
+
+Most types can automatically derive standard traits using the `derive(...)` syntax:
+
+- **`Show`** - Enables `to_string()` and string interpolation with `\{value}`
+- **`Eq`** - Enables `==` and `!=` equality operators
+- **`Compare`** - Enables `<`, `>`, `<=`, `>=` comparison operators
+- **`ToJson`** - Enables `@json.inspect()` for readable test output
+- **`Hash`** - Enables use as Map keys
+
+```moonbit
+///|
+struct Coordinate { x : Int; y : Int } derive(Show, Eq, ToJson)
+
+///|
+enum Status { Active; Inactive } derive(Show, Eq, Compare)
+```
+
+**Best practice**: Always derive `Show` and `Eq` for data types. Add `ToJson` if you plan to test them with `@json.inspect()`.
+
 ## Reference Semantics by Default
 
 MoonBit passes most types by reference semantically (the optimizer may copy

--- a/Agents.mbt.md
+++ b/Agents.mbt.md
@@ -334,7 +334,7 @@ test "map operations" {
   // Other common operations
   map.remove("b")
   assert_eq(map.contains("b"), false)
-  assert_eq(map.size(), 3)
+  assert_eq(map.length(), 3)
 }
 ```
 

--- a/Agents.mbt.md
+++ b/Agents.mbt.md
@@ -174,25 +174,26 @@ test "inspect test" {
 }
 ```
 
+## Integers, Char
 
-## Basic Types
+MoonBit supports Byte, Int, UInt, Int64, UInt64, etc. When the type is known,
+the literal can be overloaded:
 
-### View Types Concept
+```moonbit
+///|
+test "int and char literal" {
+  let a0 : Int = 1
+  let a1 : UInt = 1
+  let a2 : Int64 = 1
+  let a3 : UInt64 = 1
+  let a4 : Byte = 3
+  let a5 : Int = 'b' // this also works, a will be the unicode value
+  let a6 : Char = 'b'
 
-**Key Concept**: View types (`StringView`, `BytesView`, `ArrayView[T]`) are zero-copy, non-owning slices created with the `[:]` syntax. They don't allocate memory and are ideal for passing sub-sequences without copying data.
+}
+```
 
-- `String` → `StringView` via `s[:]` or `s[start:end]`
-- `Bytes` → `BytesView` via `b[:]` or `b[start:end]`
-- `Array[T]` → `ArrayView[T]` via `a[:]` or `a[start:end]`
-
-**When to use views**:
-- Pattern matching with rest patterns (`[first, .. rest]`)
-- Passing slices to functions without allocation overhead
-- Avoiding unnecessary copies of large sequences
-
-Convert back with `.to_string()`, `.to_bytes()`, or `.to_array()` when you need ownership.
-
-### String, StringView, Bytes, BytesView
+## String
 
 MoonBit's String is immutable utf16 encoded, `s[i]` returns an integer (code units),
 `s.get(i)` returns `Option[Int]`, `s.get_char(i)` returns `Option[Char]`. 
@@ -265,36 +266,19 @@ test "multiple line strings" {
   )
 }
 ```
+## Bytes
 
-### StringView
-
-StringView is an immutable view of a String, obtained using `s[:]`. It
-is mostly the same as String, except it does not own the memory.
-
-**Important**: `s[a:b]` may raise an error at surrogate boundaries (UTF-16 encoding edge case). You have two options:
-- Use `try! s[a:b]` if you're certain the boundaries are valid (crashes on invalid boundaries)
-- Let the error propagate to the caller for proper handling
-
-From String to StringView using `s[:]`, from StringView to String using `s.to_string()`.
-
-### Bytes, BytesView
-
-`Bytes` is immutable; use `BytesView` (`b[:]`) for slices. Indexing (`b[i]`)
-returns a `Byte`.
+Bytes is immutable; Indexing (`b[i]`) returns a `Byte`.
 
 ```moonbit
 ///|
 test "bytes literal" {
   let b0 : Bytes = b"abcd"
-  let b1 : Bytes = "abcd" // b is optional, when we know the type
-  let b2 : Bytes = [0xff, 0x00, 0x01]
-  // this also works
+  let b1 : Bytes = "abcd" // b" prefix is optional, when we know the type
+  let b2 : Bytes = [0xff, 0x00, 0x01] // Array literal overloading
 }
 ```
-
-From Bytes to BytesView using `b[:]`, from BytesView to Bytes using `b.to_bytes()`.
-
-### Array, ArrayView
+## Array
 
 MoonBit Array is resizable array, FixedArray is fixed size array.
 
@@ -302,17 +286,12 @@ MoonBit Array is resizable array, FixedArray is fixed size array.
 ///|
 test "array literal" {
   let a0 : Array[Int] = [1, 2, 3] // resizable
-  let a1 : FixedArray[Int] = [1, 2, 3]
-
+  let a1 : FixedArray[Int] = [1, 2, 3] // Array literal overloading
 }
 ```
+## Map
 
-You can get ArrayView using `a[:]`, it does not allocate which is similar to
-`StringView` and `BytesView`.
-
-### Map
-
-MoonBit provides a built-in `Map` type that preserves insertion order (like
+A built-in `Map` type that preserves insertion order (like
 JavaScript's Map):
 
 ```moonbit
@@ -322,7 +301,7 @@ let map : Map[String, Int] = { "a": 1, "b": 2, "c": 3 }
 
 ///|
 // Empty map
-let empty : Map[String, Int] = Map::new()
+let empty : Map[String, Int] = {}
 
 ///|
 /// From array of pairs
@@ -353,24 +332,26 @@ test "map operations" {
 }
 ```
 
-### Ints, Char
+## View Types 
 
-MoonBit supports Byte, Int, UInt, Int64, UInt64, etc. When the type is known,
-the literal can be overloaded:
+**Key Concept**: View types (`StringView`, `BytesView`, `ArrayView[T]`) are zero-copy, non-owning read-only slices created with the `[:]` syntax. They don't allocate memory and are ideal for passing sub-sequences without copying data.
 
-```moonbit
-///|
-test "int and char literal" {
-  let a0 : Int = 1
-  let a1 : UInt = 1
-  let a2 : Int64 = 1
-  let a3 : UInt64 = 1
-  let a4 : Byte = 3
-  let a5 : Int = 'b' // this also works, a will be the unicode value
-  let a6 : Char = 'b'
+- `String` → `StringView` via `s[:]` or `s[start:end]`
+- `Bytes` → `BytesView` via `b[:]` or `b[start:end]`
+- `Array[T]` → `ArrayView[T]` via `a[:]` or `a[start:end]`
 
-}
-```
+**Important**: StringView slice is slightly different due to unicode safety:
+`s[a:b]` may raise an error at surrogate boundaries (UTF-16 encoding edge case). You have two options:
+- Use `try! s[a:b]` if you're certain the boundaries are valid (crashes on invalid boundaries)
+- Let the error propagate to the caller for proper handling
+
+**When to use views**:
+- Pattern matching with rest patterns (`[first, .. rest]`)
+- Passing slices to functions without allocation overhead
+- Avoiding unnecessary copies of large sequences
+
+Convert back with `.to_string()`, `.to_bytes()`, or `.to_array()` when you need ownership.
+
 
 ## Complex Types
 

--- a/Agents.mbt.md
+++ b/Agents.mbt.md
@@ -177,6 +177,21 @@ test "inspect test" {
 
 ## Basic Types
 
+### View Types Concept
+
+**Key Concept**: View types (`StringView`, `BytesView`, `ArrayView[T]`) are zero-copy, non-owning slices created with the `[:]` syntax. They don't allocate memory and are ideal for passing sub-sequences without copying data.
+
+- `String` → `StringView` via `s[:]` or `s[start:end]`
+- `Bytes` → `BytesView` via `b[:]` or `b[start:end]`
+- `Array[T]` → `ArrayView[T]` via `a[:]` or `a[start:end]`
+
+**When to use views**:
+- Pattern matching with rest patterns (`[first, .. rest]`)
+- Passing slices to functions without allocation overhead
+- Avoiding unnecessary copies of large sequences
+
+Convert back with `.to_string()`, `.to_bytes()`, or `.to_array()` when you need ownership.
+
 ### String, StringView, Bytes, BytesView
 
 MoonBit's String is immutable utf16 encoded, `s[i]` returns an integer (code units),

--- a/Agents.mbt.md
+++ b/Agents.mbt.md
@@ -964,6 +964,11 @@ Packages per directory, packages without `moon.pkg.json` are not recognized.
 - **Package reference**: Use `@packagename` in test files to reference the
   tested package
 
+**Package Alias Rules**:
+- Import `"username/hello/liba"` → use `@liba.function()` (default alias is last path segment)
+- Import with custom alias `{"path": "moonbitlang/x/encoding", "alias": "enc"}` → use `@enc.function()`
+- In `_test.mbt` or `_wbtest.mbt` files, the package being tested is auto-imported
+
 Example:
 
 ```

--- a/Agents.md
+++ b/Agents.md
@@ -1,0 +1,1 @@
+Agents.mbt.md


### PR DESCRIPTION
- **Fix typos: correct loop condition and 'filde' -> 'file'**
- **Add Common Derivable Traits section explaining derive(...) syntax**
- **made a symlink**
- **Clarify package alias rules with explicit examples**
- **Condense Legacy Note section into Common Pitfalls**
- **Replace deprecated size() with length() in Map example**
- **Add View Types Concept section explaining zero-copy slices**
- **re-org**
