### PR TITLE
docs: refresh MoonBit skill docs for latest toolchain

### DIFF
--- a/moonbit-agent-guide/SKILL.md
+++ b/moonbit-agent-guide/SKILL.md
@@ -11,7 +11,7 @@ For fast, reliable task execution, follow this order:
    - Confirm expected behavior, non-goals, and compatibility constraints (target backend, public API stability, performance limits).
 
 2. **Locate module/package boundaries**
-   - Find `moon.mod.json` (module root) and relevant `moon.pkg`/`moon.pkg.json` files (package boundaries and imports).
+   - Find `moon.mod.json` (module root) and relevant `moon.pkg` files (package boundaries and imports).
 
 3. **Discover APIs before coding**
    - Prefer `moon ide doc` queries to discover existing functions/types/methods before adding new code.
@@ -19,9 +19,6 @@ For fast, reliable task execution, follow this order:
 
 4. **Reliable refactoring**
    - Use `moon ide rename` for semantic refactoring. If multiple symbols share a name, add `--loc filename:line:col`.
-   - Use `#deprecated` when old APIs should warn and be removed after migration.
-   - Use `#alias(old_api, deprecated)` when temporary backward compatibility is required during migration.
-   - Remove `#deprecated` and `#alias` shims once callers are migrated and warnings are gone.
 5. **Edit minimally and package-locally**
    - Keep changes inside the correct package, use `///|` top-level delimiters, and split code into cohesive files.
 
@@ -82,7 +79,7 @@ Use the smallest playbook that matches the request.
 MoonBit uses the `.mbt` extension for source code files and interface files with the `.mbti` extension. At
 the top-level of a MoonBit project there is a `moon.mod.json` file specifying
 the metadata of the project. The project may contain multiple packages, each
-with its own `moon.pkg` or `moon.pkg.json` (legacy mode). Subdirectories may also contain `moon.mod.json`
+with its own `moon.pkg`. Subdirectories may also contain `moon.mod.json`
 files indicating that a different set of dependencies can be used for that subdir.
 
 ## Example layout
@@ -111,7 +108,7 @@ my_module
   A MoonBit *module* is like a Go module; it is a collection of packages in subdirectories, usually corresponding to a repository or project.
   Module boundaries matter for dependency management and import paths.
 
-- **Package**: characterized by a `moon.pkg` (or `moon.pkg.json`) file in each directory.
+- **Package**: characterized by a `moon.pkg` file in each directory.
   All subcommands of `moon` will
   still be executed in the directory of the module (where `moon.mod.json` is
   located), not the current package.
@@ -174,7 +171,6 @@ my_module
 - **Don't forget @package prefix when calling functions from other packages**
 - **Don't use ++ or -- (not supported)** - use `i = i + 1` or `i += 1`
 - **Don't add explicit `try` for error-raising functions** - errors propagate automatically (unlike Swift)
-- **Legacy syntax**: Older code may use `function_name!(...)` or `function_name(...)?` - these are deprecated; use normal calls and `try?` for Result conversion
 - **Prefer range `for` loops over C-style** - `for i in 0..<(n-1) {...}` and `for j in 0..=6 {...}` are more idiomatic in MoonBit
 - **Async** - MoonBit has no `await` keyword; do not add it. Async functions and tests are characterized by those which call other async functions.
   To identify a function or test as async, simply add the `async` prefix (e.g. `[pub] async fn ...`, `async test ...`).
@@ -536,23 +532,8 @@ import {...} for "test"
 import {...} for "wbtest"
 options("is-main" : true) // other options
 ```
-or moon.pkg.json (legacy mode)
-```json
-{
-  "is_main": true,                 // Creates executable when true
-  "import": [                      // Package dependencies
-    "username/hello/liba",         // Simple import, use @liba.foo() to call functions
-    {
-      "path": "moonbitlang/x/encoding",
-      "alias": "libb"              // Custom alias, use @libb.encode() to call functions
-    }
-  ],
-  "test-import": [...],            // Imports for black-box tests, similar to import
-  "wbtest-import": [...]           // Imports for white-box tests, similar to import (rarely used)
-}
-```
 
-Packages are per directory and packages without a `moon.pkg` or `moon.pkg.json` file are not recognized.
+Packages are per directory and packages without a `moon.pkg` file are not recognized.
 
 ### Package Importing (used in moon.pkg)
 

--- a/moonbit-agent-guide/SKILL.md
+++ b/moonbit-agent-guide/SKILL.md
@@ -301,7 +301,7 @@ declare pub fn parse_yaml(s : String) -> Yaml raise
 - The `pub type Yaml` line is an intentionally opaque placeholder; the implementer chooses its representation.
 - Note the spec file can also contain normal code, not just declarations.
 
-## `moon ide [doc|peek-def|outline|find-references|hover|rename]` for code navigation and refactoring
+## `moon ide [doc|peek-def|outline|find-references|hover|rename|analyze]` for code navigation and refactoring
 
 For project-local symbols and navigation, use:
 - `moon ide doc <query>` to discover available APIs, functions, types, and methods in MoonBit. Always prefer `moon ide doc` over other approaches when exploring what APIs are available, it is **more powerful and accurate** than `grep_search` or any regex-based searching tools.
@@ -310,6 +310,7 @@ For project-local symbols and navigation, use:
 - `moon ide peek-def` for inline definition context and to locate toplevel symbols.
 - `moon ide hover sym --loc filename:line:col` to get type information at a specific location.
 - `moon ide rename <symbol> <new_name> [--loc filename:line:col]` to rename a symbol project-wide. Prefer `--loc` when symbol names are ambiguous.
+- `moon ide analyze [path]` to inspect public API usage of a package or module when planning safe refactors.
 These tools save tokens and are more precise than grepping (`grep` displays results in both definitions and call sites including comments too).
 
 ### `moon ide doc` for API Discovery
@@ -475,7 +476,7 @@ Use `moon ide outline` to scan a package or file for top-level symbols and locat
 
 - `moon ide outline dir` outlines the current package directory (per-file headers)
 - `moon ide outline parser.mbt` outlines a single file
-  This is useful when you need a quick inventory of a package, or to find the right file before `goto-definition`.
+  This is useful when you need a quick inventory of a package, or to find the right file before `peek-def`.
 - `moon ide find-references TranslationUnit` finds all references to a symbol in the current module
 
 ```bash

--- a/moonbit-agent-guide/SKILL.md
+++ b/moonbit-agent-guide/SKILL.md
@@ -935,7 +935,7 @@ pub fn binary_search(arr : ArrayView[Int], value : Int) -> Result[Int, Int] {
   // functional for loop:
   // initial state ; [predicate] ; [post-update] {
   // loop body with `continue` to update state
-  //} else { // exit block
+  //} nobreak { // exit block
   // }
   // predicate and post-update are optional
   for i = 0, j = len; i < j; {
@@ -946,7 +946,7 @@ pub fn binary_search(arr : ArrayView[Int], value : Int) -> Result[Int, Int] {
     } else {
       continue i, h // functional update of loop state
     }
-  } else { // exit of for loop
+  } nobreak { // exit of for loop
     if i < len && arr[i] == value {
       Ok(i)
     } else {

--- a/moonbit-agent-guide/ide.md
+++ b/moonbit-agent-guide/ide.md
@@ -2,115 +2,42 @@
 
 **ALWAYS use `moon ide` for code navigation in MoonBit projects instead of manual file searching, grep, or semantic search.**
 
-This tool provides two essential commands for precise code exploration:
+`moon ide` is the canonical navigation/refactoring entrypoint in current MoonBit toolchains.
 
-### Core Commands
+## Core Commands
 
-- `moon ide goto-definition` - Find where a symbol is defined
-- `moon ide find-references` - Find all usages of a symbol
+- `moon ide doc <query>`: Search API docs and symbols.
+- `moon ide peek-def <symbol> [--loc path[:line[:col]]]`: Show definition context for a symbol.
+- `moon ide find-references <symbol> [--loc path[:line[:col]]]`: Find usages of a symbol.
+- `moon ide rename <symbol> <new_name> [--loc path[:line[:col]]]`: Rename a symbol semantically.
+- `moon ide hover <symbol> --loc path:line[:col]`: Show type/doc info at a location.
+- `moon ide outline <dir|file>`: List top-level symbols in a package/file.
+- `moon ide analyze [path]`: Show public API usage summary of a package/module.
 
-### Query System
-
-Symbol lookup uses a two-part query system for precise results:
-
-#### 1. Symbol Name Query (`-query`)
-
-Fuzzy search for symbol names with package filtering support:
-
-```bash
-# Find any symbol named 'symbol'
-moon ide goto-definition -query 'symbol'
-
-# Find methods of a specific type
-moon ide goto-definition -query 'Type::method'
-
-# Find trait method implementations
-moon ide goto-definition -query 'Trait for Type with method'
-
-# Find symbol in specific package using @pkg prefix
-moon ide goto-definition -query '@moonbitlang/x encode'
-
-# Find symbol in multiple packages (searches in pkg1 OR pkg2)
-moon ide goto-definition -query '@username/mymodule/pkg1 @username/mymodule/pkg2 helper'
-
-# Find symbol in nested package
-moon ide goto-definition -query '@username/mymodule/mypkg helper'
-```
-
-**Supported symbols**: functions, constants, let bindings, types, structs, enums, traits
-
-**Package filtering**: Prefix your query with `@package_name` to scope the search. Multiple `@pkg` prefixes create an OR condition.
-
-#### 2. Tag-based Filtering (`-tags`)
-
-Pre-filter symbols by characteristics before name matching:
-
-**Visibility tags**:
-
-- `pub` - Public symbols
-- `pub all` - Public structs with all public fields
-- `pub open` - Public traits with all methods public
-- `priv` - Private symbols
-
-**Symbol type tags**:
-
-- `type` - Type definitions (struct, enum, typealias, abstract)
-- `error` - Error type definitions
-- `enum` - Enum definitions and variants
-- `struct` - Struct definitions
-- `alias` - Type/function/trait aliases
-- `let` - Top-level let bindings
-- `const` - Constant definitions
-- `fn` - Function definitions
-- `trait` - Trait definitions
-- `impl` - Trait implementations
-- `test` - Named test functions
-
-**Combine tags with logical operators**:
+## Practical Examples
 
 ```bash
-# Public functions only
-moon ide goto-definition -tags 'pub fn' -query 'my_func'
+# Discover APIs in standard library or project packages
+moon ide doc "String::*rev*"
+moon ide doc "@buffer"
 
-# Functions or constants
-moon ide goto-definition -tags 'fn | const' -query 'helper'
+# Peek definition and references
+moon ide peek-def Parser::read_u32_leb128
+moon ide find-references TranslationUnit
 
-# Public functions or constants
-moon ide goto-definition -tags 'pub (fn | const)' -query 'api'
+# Resolve ambiguous symbol by location
+moon ide peek-def parse --loc src/parser.mbt:42:8
+moon ide rename parse parse_expr --loc src/parser.mbt:42:8
 
-# Public types or traits
-moon ide goto-definition -tags 'pub (type | trait)' -query 'MyType'
+# Type/doc hover and package outline
+moon ide hover filter --loc hover.mbt:14
+moon ide outline .
+
+# Public API usage analysis
+moon ide analyze .
 ```
 
-### Practical Examples
+## Notes
 
-```bash
-# Find public function definition
-moon ide goto-definition -tags 'pub fn' -query 'maximum'
-
-# Find all references to a struct
-moon ide find-references -tags 'struct' -query 'Rectangle'
-
-# Find trait implementations
-moon ide goto-definition -tags 'impl' -query 'Show for MyType'
-
-# Find errors in specific package
-moon ide goto-definition -tags 'error' -query '@mymodule/parser ParseError'
-
-# Find symbol across multiple packages
-moon ide goto-definition -query '@moonbitlang/x @moonbitlang/core encode'
-
-# Combine package filtering with tags
-moon ide goto-definition -tags 'pub fn' -query '@username/myapp helper'
-```
-
-### Query Processing
-
-The tool processes queries in this order:
-
-1. Filter symbols by `-tags` conditions
-2. Extract package scope from `@pkg` prefixes in `-query`
-3. Fuzzy match remaining symbols by name
-4. Return top 3 best matches with location information
-
-**Best Practice**: Start with `-tags` to reduce noise, then use `@pkg` prefixes in `-query` to scope by package for precise navigation.
+- `moon ide goto-definition` and `-query`/`-tags` workflows are legacy and should not be used in new guidance.
+- If syntax or flags are unclear, run `moon ide <command> --help`.

--- a/moonbit-agent-guide/references/moonbit-language-fundamentals.mbt.md
+++ b/moonbit-agent-guide/references/moonbit-language-fundamentals.mbt.md
@@ -61,7 +61,7 @@ test "everything is expression in MoonBit" {
       break Some(i) // Exit with value
     }
     i = i + 1
-  } else { // Value when loop completes normally
+  } nobreak { // Value when loop completes normally
     None
   }
   assert_eq(found, Some(2)) // Found at index 2

--- a/moonbit-c-binding/SKILL.md
+++ b/moonbit-c-binding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: moonbit-c-binding
-description: Guide for writing MoonBit bindings to C libraries using native FFI. Use when adding extern "c" declarations, writing C stubs with moonbit.h, configuring native-stub and link.native in moon.pkg or moon.pkg.json, choosing #borrow/#owned ownership annotations, designing callback trampolines, wrapping C pointers with external objects and finalizers, converting strings across FFI, or validating bindings with AddressSanitizer.
+description: Guide for writing MoonBit bindings to C libraries using native FFI. Use when adding extern "c" declarations, writing C stubs with moonbit.h, configuring native-stub and link.native in moon.pkg, choosing #borrow/#owned ownership annotations, designing callback trampolines, wrapping C pointers with external objects and finalizers, converting strings across FFI, or validating bindings with AddressSanitizer.
 ---
 
 # MoonBit C Binding Guide
@@ -13,7 +13,7 @@ Use this skill when:
 
 - Adding `extern "c" fn` declarations for a C library
 - Writing C stub files (`moonbit.h`, `MOONBIT_FFI_EXPORT`)
-- Configuring `moon.pkg` or `moon.pkg.json` for native builds (`native-stub`, `link.native`)
+- Configuring `moon.pkg` for native builds (`native-stub`, `link.native`)
 - Choosing `#borrow` vs ownership transfer for FFI parameters
 - Wrapping C handles with external objects and finalizers
 - Implementing callback trampolines (closures or `FuncRef`)

--- a/moonbit-refactoring/SKILL.md
+++ b/moonbit-refactoring/SKILL.md
@@ -16,7 +16,7 @@ description: "Refactor MoonBit code to be idiomatic: shrink public APIs, convert
 **Start broad, then refine locally:**
 
 1. **Architecture first**: Review package structure, dependencies, and API boundaries.
-2. **Inventory** public APIs and call sites (`moon doc`, `moon ide find-references`).
+2. **Inventory** public APIs and call sites (`moon ide doc`, `moon ide find-references`).
 3. **Pick one refactor theme** (API minimization, package splits, pattern matching, loop style).
 4. **Apply the smallest safe change**.
 5. **Update docs/tests** in the same patch.
@@ -298,11 +298,12 @@ moon coverage analyze -- -f caret -F path/to/file.mbt
 ## Moon IDE Commands
 
 ```bash
-moon doc "<query>"
+moon ide doc "<query>"
 moon ide outline <dir|file>
 moon ide find-references <symbol>
 moon ide peek-def <symbol>
-moon ide rename <symbol> -new-name <new_name>
+moon ide rename <symbol> <new_name>
+moon ide analyze [path]
 moon check
 moon test
 moon info

--- a/moonbit-refactoring/SKILL.md
+++ b/moonbit-refactoring/SKILL.md
@@ -256,7 +256,7 @@ Example:
 for i = 0, acc = 0; i < xs.length(); {
   acc = acc + xs[i]
   i = i + 1
-} else { acc }
+} nobreak { acc }
 where {
   invariant: 0 <= i <= xs.length(),
   reasoning: (


### PR DESCRIPTION
## Summary
- refresh MoonBit IDE command guidance to match the current toolchain (`moon ide doc/peek-def/find-references/rename/hover/outline/analyze`)
- remove legacy-oriented content from `SKILL.md` files (including `moon.pkg.json` guidance)
- update loop completion examples from `else` to `nobreak`

## Validation
- documentation-only changes
- manually checked diffs and command examples against local `moon 0.1.20260330` help output
