### PR TITLE
[codex] add async test docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.repos/

--- a/moonbit-agent-guide/SKILL.md
+++ b/moonbit-agent-guide/SKILL.md
@@ -698,7 +698,7 @@ import {
 } for "test"
 ```
 
-```mbt check
+```mbt nocheck
 ///|
 async test "sleep completes" {
   @async.sleep(1)

--- a/moonbit-agent-guide/SKILL.md
+++ b/moonbit-agent-guide/SKILL.md
@@ -371,7 +371,9 @@ These tools save tokens and are more precise than grepping (`grep` displays resu
   - Show package `pkg` and list all its exported symbols
   - Example: `moon ide doc "@json"` - explore entire `@json` package
   - Example: `moon ide doc "@encoding/utf8"` - explore nested package
-
+- **Multiple queries**: `moon ide doc "query1" "query2" ...`
+  - Run multiple queries in one invocation and combine results
+  - Example: `moon ide doc "String" "Array" "@json"` to explore multiple types and a package at once
 - **Globbing**: Use `*` wildcard for partial matches, e.g. `moon ide doc "String::*rev*"` to find all String methods with "rev" in their name
 
 #### `moon ide doc` Examples

--- a/moonbit-agent-guide/SKILL.md
+++ b/moonbit-agent-guide/SKILL.md
@@ -640,7 +640,8 @@ For more advanced topics like `conditional compilation`, `link configuration`, `
 
 Asynchronous programming uses compiler support plus the `moonbitlang/async` runtime. The runtime supports the native backend best, has limited JavaScript support for IO-independent APIs, and does not support WebAssembly yet. For async IO examples, prefer native. Use `moon add moonbitlang/async@<version>` and `moon ide doc "@async"` to explore the API.
 
-User-facing subpackages: `@async` (core: tasks, timers, cancellation), `@async/aqueue`, `@async/semaphore`, `@async/cond_var`, `@async/io`, `@async/stdio`, `@async/pipe`, `@async/fs`, `@async/process`, `@async/socket`, `@async/tls`, `@async/http`, `@async/websocket`, `@async/signal`. Each must be imported separately in `moon.pkg`.
+User-facing subpackages: `@async` (core: tasks, timers, cancellation), `@async/aqueue`, `@async/fs, `@async/stdio`, `@async/websocket`, ..etc.
+Each must be imported separately in `moon.pkg`.
 
 1. Add the dependency and pin the native target in `moon.mod.json`:
    ```json

--- a/moonbit-agent-guide/SKILL.md
+++ b/moonbit-agent-guide/SKILL.md
@@ -548,6 +548,14 @@ moon add moonbitlang/x@0.4.6  # Add specific version
 moon update                   # Update package index
 ```
 
+### Browsing Third-Party Source (`moon fetch`)
+
+`moon fetch <author>/<module>[@<version>]` downloads a package's source into `.repos/<author>/<module>/<version>/` for offline reading (examples, internals, generated `.mbti`). It does NOT add the package to `moon.mod.json` — use `moon add` for that. Add `.repos/` to `.gitignore`.
+
+```sh
+moon fetch moonbitlang/async@0.18.1   # browse source/examples without taking a dependency
+```
+
 ### Typical Module configurations (`moon.mod.json`)
 
 ```json

--- a/moonbit-agent-guide/SKILL.md
+++ b/moonbit-agent-guide/SKILL.md
@@ -640,6 +640,8 @@ For more advanced topics like `conditional compilation`, `link configuration`, `
 
 Asynchronous programming uses compiler support plus the `moonbitlang/async` runtime. The runtime supports the native backend best, has limited JavaScript support for IO-independent APIs, and does not support WebAssembly yet. For async IO examples, prefer native. Use `moon add moonbitlang/async@<version>` and `moon ide doc "@async"` to explore the API.
 
+User-facing subpackages: `@async` (core: tasks, timers, cancellation), `@async/aqueue`, `@async/semaphore`, `@async/cond_var`, `@async/io`, `@async/stdio`, `@async/pipe`, `@async/fs`, `@async/process`, `@async/socket`, `@async/tls`, `@async/http`, `@async/websocket`, `@async/signal`. Each must be imported separately in `moon.pkg`.
+
 1. Add the dependency and pin the native target in `moon.mod.json`:
    ```json
    {
@@ -656,7 +658,7 @@ Asynchronous programming uses compiler support plus the `moonbitlang/async` runt
    supported_targets = "+native"
    options("is-main": true)
    ```
-3. Define `async fn main` (not `fn main`). Spawn concurrent tasks via `with_task_group` for structured concurrency — when the group returns, all spawned tasks have terminated:
+3. Define `async fn main` (not `fn main`). Spawn concurrent tasks via `with_task_group` for structured concurrency:
    ```mbt nocheck
    async fn main {
      @async.with_task_group(group => {
@@ -672,7 +674,18 @@ Asynchronous programming uses compiler support plus the `moonbitlang/async` runt
    }
    ```
 
-Use the arrow form `() => { ... }` for spawned closures — async-ness is inferred from context. Plain `fn() { ... }` triggers a `deprecated_syntax` warning.
+**Structured-concurrency contract for `with_task_group`:**
+
+- When `with_task_group` returns, every task spawned in the group is guaranteed to have terminated — no orphan tasks, no resource leaks.
+- If any spawned task fails (and was spawned without `allow_failure=true`), the whole group fails: every other task in the group is cancelled, and the error propagates out of `with_task_group`.
+- Cancelled tasks are not considered failures; they raise a cancellation error but don't trigger peer cancellation.
+
+**Closure syntax for `spawn_bg` / `spawn`:**
+
+- ✅ `() => { ... }` — idiomatic; async-ness is inferred from context.
+- ✅ `async fn() { ... }` — explicit annotation; equivalent to the arrow form.
+- ⚠️ `fn() { ... }` — triggers `Warning [0027] deprecated_syntax`: "this `fn` is asynchronous but not annotated with `async`". Don't use.
+- ❌ `async () => ...`, `fn() async { ... }`, `fn(args) async { ... }` — all parse errors. `async` only goes before `fn`, never before an arrow lambda or after a parameter list.
 
 ### Async tests
 
@@ -693,7 +706,7 @@ async test "sleep completes" {
 }
 ```
 
-- There is no `await` keyword. Inside an `async test`, call async functions normally.
+- There is no `await` keyword (similar to functions that raise errors). Inside an `async test`, call async functions normally.
 - Async tests run in parallel by default. Avoid shared ports, files, environment variables, and global mutable state unless each test isolates its resources.
 - Run with `moon test --target native` unless `moon.mod.json` sets `"preferred-target": "native"`. Use `moon test -v` when checking test names or async scheduling behavior.
 - In `README.mbt.md` and docstrings, `mbt check` blocks may contain `async test` blocks; make sure the package imports `moonbitlang/async` for the relevant test mode.

--- a/moonbit-agent-guide/SKILL.md
+++ b/moonbit-agent-guide/SKILL.md
@@ -636,6 +636,68 @@ To add a new package `fib` under `.`:
 
 For more advanced topics like `conditional compilation`, `link configuration`, `warning control`, and `pre-build commands`, see `references/advanced-moonbit-build.md`.
 
+## Async IO
+
+Asynchronous programming uses compiler support plus the `moonbitlang/async` runtime. The runtime supports the native backend best, has limited JavaScript support for IO-independent APIs, and does not support WebAssembly yet. For async IO examples, prefer native. Use `moon add moonbitlang/async@<version>` and `moon ide doc "@async"` to explore the API.
+
+1. Add the dependency and pin the native target in `moon.mod.json`:
+   ```json
+   {
+     "deps": { "moonbitlang/async": "0.18.1" },
+     "preferred-target": "native"
+   }
+   ```
+2. In the executable's `moon.pkg`, set `is-main`, restrict to native, and import what you need:
+   ```
+   import {
+     "moonbitlang/async",
+     "moonbitlang/async/stdio",
+   }
+   supported_targets = "+native"
+   options("is-main": true)
+   ```
+3. Define `async fn main` (not `fn main`). Spawn concurrent tasks via `with_task_group` for structured concurrency — when the group returns, all spawned tasks have terminated:
+   ```mbt nocheck
+   async fn main {
+     @async.with_task_group(group => {
+       group.spawn_bg(() => {
+         @async.sleep(50)
+         @stdio.stdout.write("A\n")
+       })
+       group.spawn_bg(() => {
+         @async.sleep(20)
+         @stdio.stdout.write("B\n")
+       })
+     })
+   }
+   ```
+
+Use the arrow form `() => { ... }` for spawned closures — async-ness is inferred from context. Plain `fn() { ... }` triggers a `deprecated_syntax` warning.
+
+### Async tests
+
+Use `async test` for tests that call async functions. The package containing the test must import `moonbitlang/async` for the test mode; import any async subpackages used by the test in the same `for "test"` block.
+
+```
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/stdio",
+} for "test"
+```
+
+```mbt check
+///|
+async test "sleep completes" {
+  @async.sleep(1)
+  inspect("done", content="done")
+}
+```
+
+- There is no `await` keyword. Inside an `async test`, call async functions normally.
+- Async tests run in parallel by default. Avoid shared ports, files, environment variables, and global mutable state unless each test isolates its resources.
+- Run with `moon test --target native` unless `moon.mod.json` sets `"preferred-target": "native"`. Use `moon test -v` when checking test names or async scheduling behavior.
+- In `README.mbt.md` and docstrings, `mbt check` blocks may contain `async test` blocks; make sure the package imports `moonbitlang/async` for the relevant test mode.
+
 # MoonBit Language Tour
 
 ## Core facts


### PR DESCRIPTION
## Summary

Adds MoonBit async testing guidance to the agent skill documentation.

## What changed

- Adds an `Async tests` subsection covering `async test` syntax and test-mode imports.
- Documents that async calls do not use `await`.
- Notes that async tests run in parallel and should isolate shared resources.
- Clarifies native-target validation guidance for async tests.
- Corrects Async IO backend wording to distinguish native support from limited JavaScript support and unsupported WebAssembly.

## Validation

- `git diff --check`
- `git diff --check HEAD~1..HEAD`
- Verified the `async fn main` and `async test` snippets in a temporary MoonBit module with `moonbitlang/async@0.18.1` using:
  - `moon check`
  - `moon test -v`
  - `moon run cmd/main`

Toolchain: `moon 0.1.20260429`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/moonbit-agent-guide/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
