### PR TITLE
[codex] Document writer interpolation sugar

### DIFF
--- a/moonbit-agent-guide/SKILL.md
+++ b/moonbit-agent-guide/SKILL.md
@@ -918,7 +918,7 @@ test "string interpolation basics" {
   let name : String = "Moon"
   let config = { "cache": 123 }
   let version = 1.0
-  println("Hello \{name} v\{version}") // "Hello Moon v1.0"
+  println("Hello \{name} v\{version}") // "Hello Moon v1"
   // ❌ Wrong - quotes inside interpolation not allowed:
   // println("  - Checking if 'cache' section exists: \{config["cache"]}")
 
@@ -930,10 +930,30 @@ test "string interpolation basics" {
   sb.write_view([ for x in [1, 2, 3] => "\{x}" ].join(","))
   sb.write_char(']')
   inspect(sb.to_string(), content="[1,2,3]")
+  let x = 42
+  let streamed = StringBuilder::new()
+  streamed <+ "hello \{x}"
+  inspect(streamed.to_string(), content="hello 42")
 }
 ```
 
 Expressions inside `\{}` can only be _basic expressions_ (no quotes, newlines, or nested interpolations). String literals are not allowed as they make lexing too difficult.
+
+String interpolation can also be streamed directly into a `Logger`/`StringBuilder`-style writer with `<+`:
+
+```moonbit
+writer <+ "hello \{x}"
+```
+
+This expands to calls on the writer:
+
+```moonbit
+writer.write_string("hello ")
+writer.write_object(x)
+```
+
+Literal string segments use `write_string`; interpolated expressions use `write_object` (not `write`) and therefore require `Show`.
+Because this uses `write_object`, interpolated `String` values are written with their `Show` representation, e.g. `"Moon"` with quotes. Use `write_string` directly when raw string contents are needed.
 
 
 ### Multiple line strings


### PR DESCRIPTION
## Summary
- Adds `writer <+ "...\{x}"` documentation near string interpolation.
- Shows the `StringBuilder` usage in the existing interpolation example.
- Documents that literal segments call `write_string` and interpolated expressions call `write_object`, not `write`.
- Notes that `String` values use `Show` formatting under `write_object`, so they are quoted.

## Validation
- `moon version` -> `moon 0.1.20260509 (8d0f1a5 2026-05-09)`
- `moon run -` with `StringBuilder` and `<+` verified `hello 42` output
- `moon run -` with `&Logger` and `<+` compiled successfully
- custom writer with `write_string` + `write_object` compiled successfully
- custom writer with `write_string` + `write` failed as expected: `Type W has no method write_object`
- `git diff --check`