### PR TITLE
CI: test against both nightly and stable channels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,17 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        channel: [nightly, latest]
+    name: test (${{ matrix.channel }})
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install MoonBit (nightly)
+      - name: Install MoonBit (${{ matrix.channel }})
         run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s nightly
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s ${{ matrix.channel }}
           echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
 
       - name: moon version


### PR DESCRIPTION
## Summary
- Run the `moon test moonbit-agent-guide/SKILL.mbt.md` job on a matrix of MoonBit toolchain channels: `nightly` and `latest` (stable).
- `fail-fast: false` so a regression on one channel doesn't mask the other.

The installer script (`cli.moonbitlang.com/install/unix.sh`) takes the channel/version as its first positional arg and defaults to `latest`, so `bash -s latest` installs the stable channel.

## Test plan
- [ ] CI passes on `nightly`
- [ ] CI passes on `latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)