### PR TITLE
CI: deny-warn + fix Option Show deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,4 @@ jobs:
         run: moon version --all
 
       - name: moon test moonbit-agent-guide/SKILL.mbt.md
-        run: moon test moonbit-agent-guide/SKILL.mbt.md
+        run: moon test moonbit-agent-guide/SKILL.mbt.md --warn-list -1-2-3-6-7-28-68 --deny-warn

--- a/moonbit-agent-guide/SKILL.md
+++ b/moonbit-agent-guide/SKILL.md
@@ -1111,8 +1111,8 @@ pub fn binary_search(arr : ArrayView[Int], value : Int) -> Result[Int, Int] {
 ///|
 test "functional for loop control flow" {
   let arr : Array[Int] = [1, 3, 5, 7, 9]
-  inspect(binary_search(arr, 5), content="Ok(2)") // Array to ArrayView implicit conversion when passing as arguments
-  inspect(binary_search(arr, 6), content="Err(3)")
+  debug_inspect(binary_search(arr, 5), content="Ok(2)") // Array to ArrayView implicit conversion when passing as arguments
+  debug_inspect(binary_search(arr, 6), content="Err(3)")
   // for iteration is supported too
   for i, v in arr {
     println("\{i}: \{v}") // `i` is index, `v` is value

--- a/moonbit-agent-guide/SKILL.md
+++ b/moonbit-agent-guide/SKILL.md
@@ -964,7 +964,7 @@ test "map literals and common operations" {
   // Map literal syntax
   let map : Map[String, Int] = { "a": 1, "b": 2, "c": 3 }
   let empty : Map[String, Int] = {} // Empty map, preferred
-  let also_empty : Map[String, Int] = Map::new()
+  let also_empty : Map[String, Int] = Map([], capacity=0)
   // From array of pairs
   let from_pairs : Map[String, Int] = Map::from_array([("x", 1), ("y", 2)])
 
@@ -1168,7 +1168,11 @@ fn g(
   let _ : Int = required
   let _ : Int? = optional
   let _ : Int = optional_with_default
-  "\{positional},\{required},\{optional},\{optional_with_default}"
+  let optional_str = match optional {
+    None => "None"
+    Some(v) => "Some(\{v})"
+  }
+  "\{positional},\{required},\{optional_str},\{optional_with_default}"
 }
 
 ///|
@@ -1185,7 +1189,14 @@ Callers still must pass it (as `None`/`Some(...)`).
 ```mbt check
 ///|
 fn with_config(a : Int?, b : Int?, c : Int) -> String {
-  "\{a},\{b},\{c}"
+  fn show_opt(o : Int?) -> String {
+    match o {
+      None => "None"
+      Some(v) => "Some(\{v})"
+    }
+  }
+
+  "\{show_opt(a)},\{show_opt(b)},\{c}"
 }
 
 ///|

--- a/moonbit-agent-guide/SKILL.md
+++ b/moonbit-agent-guide/SKILL.md
@@ -964,7 +964,7 @@ test "map literals and common operations" {
   // Map literal syntax
   let map : Map[String, Int] = { "a": 1, "b": 2, "c": 3 }
   let empty : Map[String, Int] = {} // Empty map, preferred
-  let also_empty : Map[String, Int] = Map([], capacity=0)
+  let also_empty : Map[String, Int] = Map([])
   // From array of pairs
   let from_pairs : Map[String, Int] = Map::from_array([("x", 1), ("y", 2)])
 
@@ -1168,11 +1168,9 @@ fn g(
   let _ : Int = required
   let _ : Int? = optional
   let _ : Int = optional_with_default
-  let optional_str = match optional {
-    None => "None"
-    Some(v) => "Some(\{v})"
-  }
-  "\{positional},\{required},\{optional_str},\{optional_with_default}"
+  // `to_repr` (from the prelude `Debug` trait) renders Option via the
+  // non-deprecated `Show for Repr`, avoiding the deprecated `Show for Option`.
+  "\{positional},\{required},\{to_repr(optional)},\{optional_with_default}"
 }
 
 ///|
@@ -1189,14 +1187,7 @@ Callers still must pass it (as `None`/`Some(...)`).
 ```mbt check
 ///|
 fn with_config(a : Int?, b : Int?, c : Int) -> String {
-  fn show_opt(o : Int?) -> String {
-    match o {
-      None => "None"
-      Some(v) => "Some(\{v})"
-    }
-  }
-
-  "\{show_opt(a)},\{show_opt(b)},\{c}"
+  "\{to_repr(a)},\{to_repr(b)},\{c}"
 }
 
 ///|


### PR DESCRIPTION
## Summary
Builds on #48 (CI matrix across nightly/latest). Adds `--deny-warn` to the test step so any non-trivial warning fails CI, and fixes the three deprecation warnings that this surfaces.

`--warn-list -1-2-3-6-7-28-68` disables noise from a teaching document:
- `1, 2, 3, 6, 7` — unused-style (variables, type decls, constructors, fields) — expected in standalone examples.
- `28` — `todo` placeholder (`... // parsing logic`).
- `68` — `declaration_unimplemented` (`declare pub type ...` used as forward-references in prose).

Deprecation fixes:
- `Map::new()` → `Map([], capacity=0)` (deprecation #1)
- Two `\{opt}` interpolations where `opt : Int?`. `Show for Option` is deprecated in favor of `Debug`. Replaced with explicit `match` so the example doesn't rely on the deprecated impl.

## Test plan
- [ ] `test (latest)` passes (deny-warn clean on stable channel)
- [ ] `test (nightly)` passes (deny-warn clean on nightly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)