### PR TITLE
[codex] update MoonBit module config guidance

### DIFF
--- a/moonbit-agent-guide/SKILL.md
+++ b/moonbit-agent-guide/SKILL.md
@@ -11,7 +11,7 @@ For fast, reliable task execution, follow this order:
    - Confirm expected behavior, non-goals, and compatibility constraints (target backend, public API stability, performance limits).
 
 2. **Locate module/package boundaries**
-   - Find `moon.mod.json` (module root) and relevant `moon.pkg` files (package boundaries and imports).
+   - Find `moon.mod` (module root) and relevant `moon.pkg` files (package boundaries and imports).
 
 3. **Discover APIs before coding**
    - Prefer `moon ide doc` queries to discover existing functions/types/methods before adding new code.
@@ -79,16 +79,19 @@ Use the smallest playbook that matches the request.
 # MoonBit Project Layouts
 
 MoonBit uses the `.mbt` extension for source code files and interface files with the `.mbti` extension. At
-the top-level of a MoonBit project there is a `moon.mod.json` file specifying
+the top-level of a MoonBit project there is a `moon.mod` file specifying
 the metadata of the project. The project may contain multiple packages, each
-with its own `moon.pkg`. Subdirectories may also contain `moon.mod.json`
+with its own `moon.pkg`. Subdirectories may also contain `moon.mod`
 files indicating that a different set of dependencies can be used for that subdir.
+Legacy projects may still contain `moon.mod.json`; treat it as the old module
+metadata format and migrate/update guidance to `moon.mod` instead of creating
+new `moon.mod.json` files.
 
 ## Example layout
 
 ```
 my_module
-├── moon.mod.json             # Module metadata, source field (optional) specifies the source directory of the module
+├── moon.mod                  # Module metadata; source option can specify the source directory
 ├── moon.pkg             # Package metadata (each directory is a package like Golang)
 ├── README.mbt.md             # Markdown with tested code blocks (`test "..." { ... }`)
 ├── README.md -> README.mbt.md
@@ -106,18 +109,18 @@ my_module
 └── ...                       # More package files, symbols visible to current package (like Golang)
 ```
 
-- **Module**: characterized by a `moon.mod.json` file in the project root directory.
+- **Module**: characterized by a `moon.mod` file in the project root directory.
   A MoonBit *module* is like a Go module; it is a collection of packages in subdirectories, usually corresponding to a repository or project.
   Module boundaries matter for dependency management and import paths.
 
 - **Package**: characterized by a `moon.pkg` file in each directory.
   All subcommands of `moon` will
-  still be executed in the directory of the module (where `moon.mod.json` is
+  still be executed in the directory of the module (where `moon.mod` is
   located), not the current package.
   A MoonBit *package* is the actual compilation unit (like a Go package).
   All source files in the same package are concatenated into one unit and
   thereby share all definitions throughout that package.
-  The `name` in the `moon.mod.json` file combined with the relative path to
+  The `name` in the `moon.mod` file combined with the relative path to
   the package source directory defines the package name, not the file name.
   Imports refer to module + package paths, NEVER to file names.
 
@@ -554,28 +557,33 @@ moon update                   # Update package index
 
 ### Browsing Third-Party Source (`moon fetch`)
 
-`moon fetch <author>/<module>[@<version>]` downloads a package's source into `.repos/<author>/<module>/<version>/` for offline reading (examples, internals, generated `.mbti`). It does NOT add the package to `moon.mod.json` — use `moon add` for that. Add `.repos/` to `.gitignore`.
+`moon fetch <author>/<module>[@<version>]` downloads a package's source into `.repos/<author>/<module>/<version>/` for offline reading (examples, internals, generated `.mbti`). It does NOT add the package to `moon.mod` — use `moon add` for that. Add `.repos/` to `.gitignore`.
 
 ```sh
 moon fetch moonbitlang/async@0.18.1   # browse source/examples without taking a dependency
 ```
 
-### Typical Module configurations (`moon.mod.json`)
-
-```json
-{
-  "name": "username/hello", // Required format for published modules
-  "version": "0.1.0",
-  "source": ".", // Source directory(optional, default: ".")
-  "repository": "", // Git repository URL
-  "keywords": [], // Search keywords
-  "description": "...", // Module description
-  "deps": {
-    // Dependencies from mooncakes.io, using`moon add` to add dependencies
-    "moonbitlang/x": "0.4.6"
-  }
-}
+### Typical Module configurations (`moon.mod`)
 ```
+name = "username/hello"
+version = "0.1.0"
+readme = "README.mbt.md"
+repository = ""
+license = "Apache-2.0"
+keywords = []
+description = "..."
+
+import {
+  "moonbitlang/x@0.4.6",
+}
+
+options(
+  // source: "src", // Optional; default is "."
+  "preferred-target": "native",
+)
+```
+
+Use `moon add moonbitlang/x@0.4.6` and `moon remove moonbitlang/x` to manage the `import` block instead of editing dependency versions by hand.
 
 ### Typical Package configuration (`moon.pkg`)
 
@@ -583,11 +591,26 @@ moon.pkg for simplicity
 ```
 import {
   "username/hello/liba",
-  "moonbitlang/x/encoding" @libb
+  "moonbitlang/x/encoding" @libb,
 }
-import {...} for "test"
-import {...} for "wbtest"
-options("is-main" : true) // other options
+import {
+  "username/hello/test_helpers",
+} for "test"
+import {
+  "username/hello/internal_test_helpers",
+} for "wbtest"
+options(
+  "is-main": true,
+)
+```
+
+Use `supported_targets = "native"` or another target-set expression at top level when the whole package only supports selected backends.
+
+```
+supported_targets = "native"
+options(
+  "is-main": true,
+)
 ```
 
 Packages are per directory and packages without a `moon.pkg` file are not recognized.
@@ -619,8 +642,7 @@ fn main {
 
 ### Using the Standard Library (moonbitlang/core)
 
-**MoonBit standard library (moonbitlang/core) packages were automatically imported**. MoonBit is transitioning to explicit imports—you will see a warning to add imports like `moonbitlang/core/strconv` to `moon.pkg` if you use them.
-The module is always available without adding to dependencies.
+The `moonbitlang/core` module is always available without adding it to `moon.mod` dependencies. Ordinary core packages still need explicit `moon.pkg` imports for package aliases such as `@utf8`, `@json`, or `@strconv`; add imports like `"moonbitlang/core/encoding/utf8"` when the compiler reports a missing or implicit core package.
 
 
 ### Creating Packages
@@ -634,7 +656,7 @@ To add a new package `fib` under `.`:
 
    ```
      import {
-      "username/hello/fib",
+       "username/hello/fib",
      }
    ```
 
@@ -647,12 +669,15 @@ Asynchronous programming uses compiler support plus the `moonbitlang/async` runt
 User-facing subpackages: `@async` (core: tasks, timers, cancellation), `@async/aqueue`, `@async/fs, `@async/stdio`, `@async/websocket`, ..etc.
 Each must be imported separately in `moon.pkg`.
 
-1. Add the dependency and pin the native target in `moon.mod.json`:
-   ```json
-   {
-     "deps": { "moonbitlang/async": "0.18.1" },
-     "preferred-target": "native"
+1. Add the dependency and pin the native target in `moon.mod`:
+   ```
+   import {
+     "moonbitlang/async@0.18.1",
    }
+
+   options(
+     "preferred-target": "native",
+   )
    ```
 2. In the executable's `moon.pkg`, set `is-main`, restrict to native, and import what you need:
    ```
@@ -660,8 +685,10 @@ Each must be imported separately in `moon.pkg`.
      "moonbitlang/async",
      "moonbitlang/async/stdio",
    }
-   supported_targets = "+native"
-   options("is-main": true)
+   supported_targets = "native"
+   options(
+     "is-main": true,
+   )
    ```
 3. Define `async fn main` (not `fn main`). Spawn concurrent tasks via `with_task_group` for structured concurrency:
    ```mbt nocheck
@@ -714,7 +741,7 @@ async test "sleep completes" {
 
 - There is no `await` keyword (similar to functions that raise errors). Inside an `async test`, call async functions normally.
 - Async tests run in parallel by default. Avoid shared ports, files, environment variables, and global mutable state unless each test isolates its resources.
-- Run with `moon test --target native` unless `moon.mod.json` sets `"preferred-target": "native"`. Use `moon test -v` when checking test names or async scheduling behavior.
+- Run with `moon test --target native` unless `moon.mod` sets `"preferred-target": "native"`. Use `moon test -v` when checking test names or async scheduling behavior.
 - In `README.mbt.md` and docstrings, `mbt check` blocks may contain `async test` blocks; make sure the package imports `moonbitlang/async` for the relevant test mode.
 
 # MoonBit Language Tour
@@ -898,7 +925,8 @@ test "string indexing and utf8 encode/decode" {
   let eq_char : Char = '='
   // s[0] == eq_char // ❌ Won't compile - eq_char is not a literal, lhs is UInt while rhs is Char
   // Use: s[0] == '=' or s.get_char(0) == Some(eq_char)
-  let bytes = @utf8.encode("中文") // utf8 encode package is in stdlib
+  // Requires `"moonbitlang/core/encoding/utf8"` in `moon.pkg`.
+  let bytes = @utf8.encode("中文")
   assert_true(bytes is [0xe4, 0xb8, 0xad, 0xe6, 0x96, 0x87])
   let s2 : String = @utf8.decode(bytes) // decode utf8 bytes back to String
   assert_true(s2 is "中文")


### PR DESCRIPTION
## Summary

Update the MoonBit agent guide for the migration from `moon.mod.json` to `moon.mod`.

## Changes

- Treat `moon.mod` as the module boundary throughout the workflow and layout guidance.
- Add a short legacy note for old `moon.mod.json` projects.
- Replace stale JSON module config examples with current `moon.mod` syntax.
- Update dependency, async, package, and core import examples to match the current MoonBit toolchain.
- Clarify that checked `@utf8` examples require an explicit `moon.pkg` import.

## Validation

- `moon check --warn-list +unnecessary_annotation` on a temp module with `SKILL.mbt.md` copied as `README.mbt.md`
- `moon test --warn-list +unnecessary_annotation` on the same temp module: 14 passed
- `moon fmt --check README.mbt.md`
- `git diff --check -- moonbit-agent-guide/SKILL.md`

Expected guide-example warnings remain for intentional stubs, `...`, unused teaching variables, and warning 73 examples.