### PR TITLE
[codex] clarify MoonBit checked error handling

### DIFF
--- a/moonbit-agent-guide/SKILL.md
+++ b/moonbit-agent-guide/SKILL.md
@@ -169,16 +169,19 @@ my_module
 
 - **Don't use uppercase for variables/functions** - compilation error
 - **Don't forget `mut` for mutable record fields** - immutable by default (note that Arrays typically do NOT need `mut` unless completely reassigning to the variable - simple push operations, for example, do not need `mut`)
-- **Don't ignore error handling** - errors must be explicitly handled
+- **Don't ignore error handling** - either handle errors explicitly, or declare `raise` on the caller and let checked errors propagate
 - **Don't use `return` unnecessarily** - the last expression is the return value
 - **Don't create methods without Type:: prefix** - methods need explicit type prefix
 - **Don't forget to handle array bounds** - use `get()` for safe access
 - **Don't forget @package prefix when calling functions from other packages**
 - **Don't use ++ or -- (not supported)** - use `i = i + 1` or `i += 1`
-- **Don't add explicit `try` for error-raising functions** - errors propagate automatically (unlike Swift)
-- **Legacy syntax**: Legacy code may use `function_name!(...)` or `function_name(...)?` - these are deprecated, use normal calls.
+- **Don't add explicit `try` for error propagation** - inside a `raise` function, call error-raising functions normally; use `catch` to handle locally and `try!` only when aborting is intended
+- **Legacy syntax**: Legacy code may use `function_name!(...)` or `function_name(...)?` - these are deprecated; use normal calls for propagation.
+- **Don't write an empty parameter list for `main`** - use `fn main { ... }` or `fn main raise { ... }`, not `fn main() { ... }` or `fn main() raise ... { ... }`
+- **Don't write record-style enum or error constructor fields** - labeled constructor fields use `label~ : Type`, e.g. `InvalidNumber(input~ : String)`, not `InvalidNumber(input: String)`
 - **Prefer range `for` loops over C-style** - `for i in 0..<(n-1) {...}` and `for j in 0..=6 {...}` are more idiomatic in MoonBit
-- **Async** - MoonBit has no `await` keyword; do not add it. Async functions and tests are characterized by those which call other async functions.
+- **Async** - MoonBit has no `await` keyword; do not add it. Async functions default to raising, so do not add `raise`; add `noraise` only when the async body must not raise.
+  Async functions and tests are characterized by those which call other async functions.
   To identify a function or test as async, simply add the `async` prefix (e.g. `[pub] async fn ...`, `async test ...`).
 
 # `moon` Essentials
@@ -294,7 +297,8 @@ Use snapshot tests as it is easy to update when behavior changes.
 - Black-box by default: Call only public APIs via `@package.fn`. Use white-box tests only when private members matter.
 - Grouping: Combine related checks in one `test "..." { ... }` block for speed and clarity.
 - Panics: Name tests with prefix `test "panic ..." {...}`; if the call returns a value, wrap it with `ignore(...)` to silence warnings.
-- Errors: Use `try? f()` to get `Result[...]` and `inspect` it when a function may raise.
+- Errors: For expected success, call error-raising functions directly. If a call unexpectedly raises, the test fails with the actual error. For expected failure, use `try ... catch ... noraise`, inspect the error in `catch`, and fail explicitly in `noraise`.
+  Default expected-failure shape: `try f() catch { err => inspect(err) } noraise { _ => fail("expected to fail") }`.
 
 ### Docstring tests
 
@@ -707,6 +711,9 @@ Each must be imported separately in `moon.pkg`.
    }
    ```
 
+- Async functions have a raising effect by default. Write `async fn main { ... }` or `async fn f(...) { ... }`, not `async fn main raise { ... }`.
+- Use `async fn f(...) noraise { ... }` only when the async body must not raise. A `noraise` async function cannot call fallible APIs unless it handles their errors locally.
+
 **Structured-concurrency contract for `with_task_group`:**
 
 - When `with_task_group` returns, every task spawned in the group is guaranteed to have terminated — no orphan tasks, no resource leaks.
@@ -740,6 +747,7 @@ async test "sleep completes" {
 ```
 
 - There is no `await` keyword (similar to functions that raise errors). Inside an `async test`, call async functions normally.
+- `async test` also has the async raising effect by default; do not add `raise`.
 - Async tests run in parallel by default. Avoid shared ports, files, environment variables, and global mutable state unless each test isolates its resources.
 - Run with `moon test --target native` unless `moon.mod` sets `"preferred-target": "native"`. Use `moon test -v` when checking test names or async scheduling behavior.
 - In `README.mbt.md` and docstrings, `mbt check` blocks may contain `async test` blocks; make sure the package imports `moonbitlang/async` for the relevant test mode.
@@ -762,10 +770,17 @@ async test "sleep completes" {
 
 ## MoonBit Error Handling (Checked Errors)
 
-MoonBit uses checked error-throwing functions, not unchecked exceptions. All errors are a subtype of `Error` and you can declare your own error types using `suberror`.
-Use `raise` in signatures to declare error types and let errors propagate by
-default.  `try { } catch { }`
-to handle errors explicitly. Use `try!` to abort if it does raise. Occasionally, use `try?` to convert to `Result[...]` in tests for inspection.
+MoonBit uses checked error-throwing functions, not unchecked exceptions. All errors are a subtype of `Error`, and you can declare your own error types using `suberror`.
+
+Checked errors are tracked in function signatures, not marked at every call site. A function that may raise declares `raise` or `raise SomeError`. If the caller only wants to pass that error upward, the caller also declares a compatible `raise` and calls the raising function normally.
+
+- Plain call inside a `raise` function: propagate automatically.
+- `fn main raise { ... }` is valid for synchronous command-line probes and small examples that should propagate errors. For async entry points, use `async fn main { ... }`; async functions can raise by default.
+- In `suberror` constructors, labeled payloads use `label~ : Type`; call and pattern-match them with `label=value`.
+- `expr catch { ... }` or `try { ... } catch { ... }`: handle explicitly.
+- `try! expr`: abort if an error is raised.
+
+Do not add Swift-style `try` for propagation. Do not use legacy `function_name!(...)` or `function_name(...)?` syntax for new code.
 
 ```mbt check
 ///|
@@ -807,10 +822,16 @@ fn div(x : Int, y : Int) -> Int raise {
 }
 
 ///|
-test "inspect raise function" {
-  let result : Result[Int, Error] = try? div(1, 0)
-  guard result is Err(Failure::Failure(msg)) && msg.contains("Division by zero") else {
-    fail("Expected error")
+test "expected success calls directly" {
+  inspect(div(6, 3), content="2")
+}
+
+///|
+test "expected failure handles the raised error" {
+  try div(1, 0) catch {
+    err => inspect(err)
+  } noraise {
+    _ => fail("expected to fail")
   }
 }
 
@@ -819,6 +840,8 @@ test "inspect raise function" {
 ///|
 /// Propagate automatically
 fn use_parse(s : String, position~ : Position) -> Int raise ParseError {
+  // This plain call is the correct propagation syntax.
+  // `try! parse_int(...)` would abort instead of propagating.
   let x = parse_int(s, position~) // label punning, equivalent to position=position
   // Error auto-propagates by default.
   // Unlike Swift, you do not need to mark `try` for functions that can raise
@@ -849,7 +872,7 @@ fn handle_parse(s : String, position~ : Position) -> Int {
 
 Important: When calling a function that can raise errors, if you only want to
 propagate the error, you do not need any marker; the compiler infers it.
-Note that all `async` functions automatically can raise errors without explicitly stating this.
+Async functions automatically can raise errors without explicitly stating this. Do not add `raise` to async functions for propagation; add `noraise` only when the async function must reject unhandled errors.
 
 ## Integer, Char and overloaded literals
 
@@ -1106,7 +1129,13 @@ test "user defined types: enum and struct" {
 
 ```mbt check
 ///|
-pub fn binary_search(arr : ArrayView[Int], value : Int) -> Result[Int, Int] {
+pub(all) enum SearchIndex {
+  Found(Int)
+  InsertionPoint(Int)
+} derive(Debug, Eq)
+
+///|
+pub fn binary_search(arr : ArrayView[Int], value : Int) -> SearchIndex {
   let len = arr.length()
   // functional for loop:
   // initial state ; [predicate] ; [post-update] {
@@ -1124,9 +1153,9 @@ pub fn binary_search(arr : ArrayView[Int], value : Int) -> Result[Int, Int] {
     }
   } nobreak { // exit of for loop
     if i < len && arr[i] == value {
-      Ok(i)
+      Found(i)
     } else {
-      Err(i)
+      InsertionPoint(i)
     }
   } where {
     proof_invariant: 0 <= i && i <= j && j <= len,
@@ -1155,8 +1184,8 @@ pub fn binary_search(arr : ArrayView[Int], value : Int) -> Result[Int, Int] {
 ///|
 test "functional for loop control flow" {
   let arr : Array[Int] = [1, 3, 5, 7, 9]
-  debug_inspect(binary_search(arr, 5), content="Ok(2)") // Array to ArrayView implicit conversion when passing as arguments
-  debug_inspect(binary_search(arr, 6), content="Err(3)")
+  debug_inspect(binary_search(arr, 5), content="Found(2)") // Array to ArrayView implicit conversion when passing as arguments
+  debug_inspect(binary_search(arr, 6), content="InsertionPoint(3)")
   // for iteration is supported too
   for i, v in arr {
     println("\{i}: \{v}") // `i` is index, `v` is value

--- a/moonbit-agent-guide/SKILL.md
+++ b/moonbit-agent-guide/SKILL.md
@@ -813,10 +813,10 @@ fn parse_int(s : String, position~ : Position) -> Int raise ParseError {
 }
 
 ///|
-/// Just declare `raise` to not track specific error types
-fn div(x : Int, y : Int) -> Int raise {
+/// Declare a specific error type when callers should handle it precisely
+fn div(x : Int, y : Int) -> Int raise ValueError {
   if y is 0 {
-    fail("Division by zero")
+    raise ValueError::ValueError("Division by zero")
   }
   x / y
 }
@@ -829,7 +829,7 @@ test "expected success calls directly" {
 ///|
 test "expected failure handles the raised error" {
   try div(1, 0) catch {
-    err => inspect(err)
+    ValueError::ValueError(message) => inspect(message, content="Division by zero")
   } noraise {
     _ => fail("expected to fail")
   }


### PR DESCRIPTION
## Summary

This updates the MoonBit agent guide to make checked error handling harder to confuse with Rust/Swift-style result or explicit-try patterns.

## Changes

- Clarify that normal calls inside `raise` functions propagate checked errors automatically.
- Document the preferred expected-failure test shape with `try ... catch ... noraise`.
- Add guardrails for common weak-model mistakes: `fn main` syntax, labeled constructor payload syntax, and async error effects.
- Clarify that async functions can raise by default and should use `noraise` only when unhandled errors must be rejected.

## Validation

- `git diff --cached --check`
- `rg -n "try\\?|Result|Ok\\(|Err\\(" moonbit-agent-guide/SKILL.md || true`

Both checks passed before committing.