### PR TITLE
docs: align inspect/derive guidance with the Show→Debug migration

### DIFF
--- a/moonbit-agent-guide/SKILL.md
+++ b/moonbit-agent-guide/SKILL.md
@@ -180,6 +180,9 @@ my_module
 - **Don't write an empty parameter list for `main`** - use `fn main { ... }` or `fn main raise { ... }`, not `fn main() { ... }` or `fn main() raise ... { ... }`
 - **Don't write record-style enum or error constructor fields** - labeled constructor fields use `label~ : Type`, e.g. `InvalidNumber(input~ : String)`, not `InvalidNumber(input: String)`
 - **Prefer range `for` loops over C-style** - `for i in 0..<(n-1) {...}` and `for j in 0..=6 {...}` are more idiomatic in MoonBit
+- **Don't use `for { ... }` for infinite loops** - write `for ;; { ... }` instead
+- **Don't `derive(Show)` for debugging** - derive `Debug` and use `debug_inspect()` for test/diagnostic output (`\{to_repr(value)}` for interpolation of composed values). Reserve a manual `impl Show` for specialized display formats (JSON, XML, domain text)
+- **Don't call `@json.inspect()`** - use the prelude `json_inspect(value, ...)` without a package prefix
 - **Async** - MoonBit has no `await` keyword; do not add it. Async functions default to raising, so do not add `raise`; add `noraise` only when the async body must not raise.
   Async functions and tests are characterized by those which call other async functions.
   To identify a function or test as async, simply add the `async` prefix (e.g. `[pub] async fn ...`, `async test ...`).
@@ -286,11 +289,11 @@ Note you can also use `moon -C dir check` to run commands in a specific director
 
 Use snapshot tests as it is easy to update when behavior changes.
 
-- **Snapshot Tests**: `inspect(value, content="...")`. If unknown, write `inspect(value)` and run `moon test --update` (or `moon test -u`).
-  - Use regular `inspect()` for simple values (uses `Show` trait)
-  - Use `@json.inspect()` for complex nested structures (uses `ToJson` trait, produces more readable output)
-  - It is encouraged to `inspect` or `@json.inspect` the whole return value of a function if
-    the whole return value is not huge, this makes the test simple. You need `impl (Show|ToJson) for YourType` or `derive (Show, ToJson)`.
+- **Snapshot Tests**: write `inspect(value)` / `debug_inspect(value)` / `json_inspect(value)`, then run `moon test --update` (or `moon test -u`) to fill in `content=`.
+  - Use `inspect()` for values that implement `Show` (primitives, or types with a manual `impl Show`).
+  - Use `debug_inspect()` for any type that derives `Debug` — the default for your own data types.
+  - Use `json_inspect()` for complex nested structures (uses the `ToJson` trait, produces more readable output).
+  - It is encouraged to inspect the whole return value of a function if it is not huge; this keeps the test simple. Derive `Debug` and/or `ToJson` (or `impl Show`) on `YourType` accordingly.
 - **Update workflow**: After changing code that affects output, run `moon test --update` to regenerate snapshots, then review the diffs in your test files (the `content=` parameter will be updated automatically).
 - **Validation order**: Follow the canonical sequence in `Agent Workflow` and `Fast Task Playbooks`.
 

--- a/moonbit-agent-guide/references/moonbit-language-fundamentals.mbt.md
+++ b/moonbit-agent-guide/references/moonbit-language-fundamentals.mbt.md
@@ -30,7 +30,7 @@ pub impl Show for Rect with output(_self, logger) {
 enum MyOption {
   MyNone
   MySome(Int)
-} derive(Show, ToJson, Eq, Compare)
+} derive(Debug, ToJson, Eq, Compare)
 
 ///|
 ///  match + loops are expressions
@@ -101,13 +101,13 @@ pub fn maximum(xs : Array[Int]) -> Int raise {
 pub(all) struct Point {
   x : Int
   mut y : Int
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 pub enum LoadState {
   Loading // semicolon `;` is optional when we have a newline
   Ready(Int) // Enum variants must start uppercase
-} derive(Show, Eq, ToJson)
+} derive(Debug, Eq, ToJson)
 // pub means it can only be pattern matched outside the package
 // but it can not be created outside the package, use `pub(all)` otherwise
 
@@ -123,8 +123,8 @@ test "inspect test" {
   inspect(result, content="3")
   // The `content` can be auto-corrected by running `moon test --update`
   let point = Point::{ x: 10, y: 20 }
-  // For complex structures, use @json.inspect for better readability:
-  @json.inspect(point, content={ "x": 10, "y": 20 })
+  // For complex structures, use json_inspect for better readability:
+  json_inspect(point, content={ "x": 10, "y": 20 })
 }
 ```
 
@@ -153,7 +153,7 @@ let raw : Int = distance.0 // Access first field with .0
 struct Addr {
   host : String
   port : Int
-} derive(Show, Eq, ToJson, FromJson)
+} derive(Debug, Eq, ToJson, FromJson)
 
 ///|
 /// Structural types with literal syntax
@@ -170,10 +170,11 @@ let config : Addr = Addr::{
 
 Most types can automatically derive standard traits using the `derive(...)` syntax:
 
-- **`Show`** - Enables `to_string()` and string interpolation with `\{value}`
+- **`Debug`** - Enables `debug_inspect()` for structural test/diagnostic output; the derivable default for your own data types. For interpolation of composed values use `\{to_repr(value)}`
+- **`Show`** - Produces specialized display strings (JSON, XML, user-facing text). Deriving it for debugging is deprecated in favor of `Debug`; write a manual `impl Show for T with output(self, logger) { ... }` only for genuine display formats
 - **`Eq`** - Enables `==` and `!=` equality operators
 - **`Compare`** - Enables `<`, `>`, `<=`, `>=` comparison operators
-- **`ToJson`** - Enables `@json.inspect()` for readable test output
+- **`ToJson`** - Enables `json_inspect()` for readable test output
 - **`Hash`** - Enables use as Map keys
 
 ```mbt check
@@ -181,16 +182,16 @@ Most types can automatically derive standard traits using the `derive(...)` synt
 struct Coordinate {
   x : Int
   y : Int
-} derive(Show, Eq, ToJson)
+} derive(Debug, Eq, ToJson)
 
 ///|
 enum Status {
   Active
   Inactive
-} derive(Show, Eq, Compare)
+} derive(Debug, Eq, Compare)
 ```
 
-**Best practice**: Always derive `Show` and `Eq` for data types. Add `ToJson` if you plan to test them with `@json.inspect()`.
+**Best practice**: Derive `Debug` and `Eq` for data types (use `debug_inspect()` in tests; `\{to_repr(value)}` for interpolation). Add `ToJson` if you plan to test them with `json_inspect()`. Implement `Show` by hand only for specialized display formats (JSON, XML, user-facing text).
 
 ## Reference Semantics by Default
 


### PR DESCRIPTION
Updates the agent-facing docs (`SKILL.md` and `references/moonbit-language-fundamentals.mbt.md`) so they no longer teach forms that the current nightly toolchain warns on (`moon 0.1.20260522` / `moonc v0.9.3`).