### PR TITLE
[codex] Clarify streaming interpolation macros

### DIFF
--- a/moonbit-agent-guide/SKILL.md
+++ b/moonbit-agent-guide/SKILL.md
@@ -988,11 +988,14 @@ test "string interpolation basics" {
 
 Expressions inside `\{}` must be single-line expressions.
 Nested interpolations and string literals are supported, but line breaks inside `\{}` are not.
-
-String interpolation can also be streamed directly into a `Logger`/`StringBuilder`-style writer with `<+`:
+#### `<+` and `<?` macros for streaming interpolation
+String interpolation can be streamed directly into a `Logger`/`StringBuilder`-style writer with `<+`, or conditionally through an optional writer with `<?`:
 
 ```mbt nocheck
 writer <+ "hello \{x}"
+writer <+ {"key1": value, "key2": value2}
+lhs <? "hello \{x}"
+lhs <? {"key1": value, "key2": value2}
 ```
 
 This expands to calls on the writer:
@@ -1000,11 +1003,18 @@ This expands to calls on the writer:
 ```mbt nocheck
 writer.write_string("hello ")
 writer.write(x)
+writer.write_object_begin()
+writer.write_object_field("key1", value)
+writer.write_object_field("key2", value2)
+writer.write_object_end()
+if lhs is Some(l) { l <+ "hello \{x}" }
 ```
 
 Literal string segments use `write_string`; interpolated expressions use `write`.
-The expansion is macro-style: it depends on how the `writer` type implements the `write_string` and `write` methods. Types such as HTMLBuilder or JSONBuilder can support interpolation and streaming with the same syntax but different semantics.
-Because MoonBit allows local methods on foreign types, a package can adapt an existing writer type to this syntax by adding local `write_string` and `write` methods.
+For `<?`, `None` performs no write; `Some(writer)` applies the same `<+` expansion to the wrapped writer.
+The right-hand side of `<+` and `<?` must be a template string/multiline template string or a map object literal, not an arbitrary expression.
+The expansion is macro-style: it depends on how the `writer` type implements `write_string` and `write` for template strings, plus `write_object_begin`, `write_object_field`, and `write_object_end` for map object literals. Types such as HTMLBuilder or JSONBuilder can support interpolation and streaming with the same syntax but different semantics.
+Because MoonBit allows local methods on foreign types, a package can adapt an existing writer type to this syntax by adding those local writer methods.
 
 ### Multiple line strings
 


### PR DESCRIPTION
## Summary

Clarifies the MoonBit guide section for `<+` and `<?` streaming interpolation macros.

## Details

- Shows valid `<?` right-hand-side forms instead of an arbitrary identifier expression.
- Documents that `<?` skips writes for `None` and applies the `<+` expansion for `Some(writer)`.
- Calls out the additional writer methods required for map object literals: `write_object_begin`, `write_object_field`, and `write_object_end`.

## Validation

- `git diff --check`
- `moon run -e '...'` snippet covering `<+` template strings, `<+` map object literals, `<?` template strings, `<?` map object literals, and `None` no-op behavior.
