### PR TITLE
[codex] Document moon explain attribute help

### DIFF
--- a/moonbit-agent-guide/SKILL.md
+++ b/moonbit-agent-guide/SKILL.md
@@ -255,10 +255,12 @@ EOF
 )"
   ````
   Get the diagnostics with "unused" in the message, which can be used to find unused code.
-- `moon explain` - Show built-in documentation for compiler diagnostics.
-  - `moon explain --diagnostics` lists warning mnemonics and IDs.
-  - `moon explain --diagnostics 31` explains warning 31 (`unused_optional_argument`).
-  - `moon explain --diagnostics unused_optional_argument` explains the same warning by mnemonic.
+- `moon explain` - Show built-in documentation for compiler diagnostics and language topics.
+  - `moon explain --diagnostic` lists warning mnemonics and IDs.
+  - `moon explain --diagnostic 31` explains warning 31 (`unused_optional_argument`).
+  - `moon explain --diagnostic unused_optional_argument` explains the same warning by mnemonic.
+  - `moon explain --attribute` lists supported attributes such as `#deprecated`, `#alias`, `#cfg`, `#coverage.skip`, and `#warnings`.
+  - `moon explain --attribute deprecated` explains the `#deprecated` attribute and its supported forms.
 - `moon add package` - Add dependency
 - `moon remove package` - Remove dependency
 - `moon fmt` - Format code - should be run periodically - note that the files may be rewritten


### PR DESCRIPTION
## Summary

Updates `moonbit-agent-guide/SKILL.md` to document `moon explain` support for language topics, including attribute listing and per-attribute help.

Also normalizes the diagnostic examples to the canonical `--diagnostic` spelling shown by `moon explain --help`.

## Verification

- `moon explain --help`
- `moon explain --attribute`
- `moon explain --attribute deprecated`
- `moon explain --diagnostic unused_optional_argument`
- `moon explain --attributes` was checked and is rejected by the current available toolchain with a suggestion to use `--attribute`
- `moon check` is not applicable at repo root: this repository has no `moon.mod`, `moon.mod.json`, or `moon.work`