### PR TITLE
Document moon run --profile for hot-path profiling

### DIFF
--- a/moonbit-agent-guide/SKILL.md
+++ b/moonbit-agent-guide/SKILL.md
@@ -265,6 +265,13 @@ EOF
 - `moon remove package` - Remove dependency
 - `moon fmt` - Format code - should be run periodically - note that the files may be rewritten
 Note you can also use `moon -C dir check` to run commands in a specific directory.
+
+### Profiling Hot Paths (`moon run --profile`)
+
+`moon run --profile --target native --release cmd/<main>` runs a native release build under a sampling profiler and prints ranked **self-time** and **inclusive-time** tables plus a "runtime leaf costs attributed to MoonBit callers" section (which maps allocation, reference-counting, and string-equality costs back to *your* functions), alongside a `profile.json` and a `.trace` you can open in Instruments. On macOS it needs Xcode's `xcrun xctrace`, so install the full Xcode (not just the command-line tools) first. A single parse or compute is far too short to sample meaningfully, so point the profiled `main` at a loop that exercises the hot path a few hundred times over a representative fixture; this loop harness is throwaway and should never be committed.
+
+Read **self-time** for *which function burns cycles* and **inclusive-time** for *which call subtree dominates*, then work a tight loop: profile, fix the top item, re-profile. Always re-baseline before trusting a delta — sampled timings drift with machine load, so build and benchmark the branch and `main` back-to-back (interleaved) rather than comparing against a number from an earlier session.
+
 ### Test Commands
 
 - `moon test` - Run all tests


### PR DESCRIPTION
## Summary

Adds a short **Profiling Hot Paths** subsection to Essential Commands in `SKILL.md`, based on hands-on use of `moon run --profile` during a parser-optimization effort. There was no profiling guidance in the guide before.

Two paragraphs cover what an agent actually needs:
- **What it does / setup**: native-release sampling profiler; the self-time / inclusive-time / "runtime leaf costs attributed to MoonBit callers" output (the leaf attribution is the useful part — it maps allocation, refcount, and string-equality costs back to your own functions); `profile.json` + `.trace`; and the macOS `xcrun xctrace` (full Xcode) dependency.
- **How to use it well**: profile a *loop* over a representative fixture (a single run is too short to sample), keep the harness throwaway, read self-time vs inclusive-time for different questions, and re-baseline interleaved against `main` because sampled timings drift with machine load.

## Notes

- Single file, additive (+7 lines), no restructuring.
- Phrasing and terseness match the surrounding command entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)