### PR TITLE
[codex] Document real-newline moon run snippets

### DIFF
--- a/moonbit-agent-guide/SKILL.md
+++ b/moonbit-agent-guide/SKILL.md
@@ -212,6 +212,21 @@ my_module
   ```
   moon run -e 'fn main { println("Hello, MoonBit!") }'
   ```
+  For multi-line `-e` snippets, especially snippets with `import { ... }`,
+  pass real newlines. Do not put literal `\n` escapes inside single quotes;
+  MoonBit will see backslash characters, not line breaks. Use command
+  substitution with a quoted heredoc:
+  ```bash
+  moon run --target native -e "$(cat <<'EOF'
+  import {
+    "moonbitlang/x/sys"
+  }
+  fn main {
+    println(@sys.get_cli_args().join("|"))
+  }
+  EOF
+  )"
+  ```
 - `moon build` - Build project
   (`moon run` and `moon build` both support `--target`; `moon build` also supports `--diagnostic-limit <N>`)
 - `moon check` - Type check without building, use it REGULARLY, it is fast


### PR DESCRIPTION
## Summary

Document the safe pattern for multi-line `moon run -e` snippets that need imports.

## Why

Shell snippets written as single-quoted strings with literal `\n` pass backslash characters to MoonBit instead of real line breaks. That makes inline imports fail in a way that looks like a MoonBit parsing/import issue rather than a shell quoting issue.

## Validation

- Reviewed the `SKILL.md` diff for scope and Markdown placement.
- Ran the documented `moon run --target native -e "$(cat <<'EOF' ... EOF)"` pattern successfully.
- Ran `quick_validate.py` against the skill using a temporary Python virtualenv with PyYAML installed: `Skill is valid!`.
