### PR TITLE
Simplify workflow and refresh MoonBit test blocks

### DIFF
--- a/moonbit-agent-guide/SKILL.md
+++ b/moonbit-agent-guide/SKILL.md
@@ -962,7 +962,9 @@ test "string indexing and utf8 encode/decode" {
   guard b0 is ('\n' | 'h' | 'b' | 'a'..='z') && s is [.. "hello", .. rest] else {
     fail("unexpected string content")
   }
-  guard rest is " world"  // otherwise will crash (guard without else)
+  guard rest is " world" else {
+    fail("unexpected string suffix")
+  }
 
   // In check mode (expression with explicit type), ('\n' : UInt16) is valid.
 
@@ -1066,7 +1068,7 @@ test "multi-line string literals" {
 test "map literals and common operations" {
   // Map literal syntax
   let map : Map[String, Int] = { "a": 1, "b": 2, "c": 3 }
-  let empty : Map[String, Int] = {} // Empty map, preferred
+  let empty : Map[String, Int] = Map([]) // Empty map
   let also_empty : Map[String, Int] = Map([])
   // From array of pairs
   let from_pairs : Map[String, Int] = Map::from_array([("x", 1), ("y", 2)])
@@ -1277,9 +1279,8 @@ fn g(
   let _ : Int = required
   let _ : Int? = optional
   let _ : Int = optional_with_default
-  // `to_repr` (from the prelude `Debug` trait) renders Option via the
-  // non-deprecated `Show for Repr`, avoiding the deprecated `Show for Option`.
-  "\{positional},\{required},\{to_repr(optional)},\{optional_with_default}"
+  // `Repr` renders Option without relying on its deprecated `Show` implementation.
+  "\{positional},\{required},\{Repr(optional)},\{optional_with_default}"
 }
 
 ///|
@@ -1296,7 +1297,7 @@ Callers still must pass it (as `None`/`Some(...)`).
 ```mbt check
 ///|
 fn with_config(a : Int?, b : Int?, c : Int) -> String {
-  "\{to_repr(a)},\{to_repr(b)},\{c}"
+  "\{Repr(a)},\{Repr(b)},\{c}"
 }
 
 ///|

--- a/moonbit-agent-guide/SKILL.md
+++ b/moonbit-agent-guide/SKILL.md
@@ -17,18 +17,16 @@ For fast, reliable task execution, follow this order:
    - Prefer `moon ide doc` queries to discover existing functions/types/methods before adding new code.
    - Use `moon ide outline`, `moon ide peek-def`, and `moon ide find-references` for semantic navigation.
 
-4. **Reliable refactoring**
-   - Use `moon ide rename` for semantic refactoring. If multiple symbols share a name, add `--loc filename:line:col`.
-   - If you want maintain backwards compatibility, use `#alias(old_api, deprecated)`.
-   
-5. **Edit minimally and package-locally**
+4. **Edit minimally and package-locally**
    - Keep changes inside the correct package, use `///|` top-level delimiters, and split code into cohesive files.
+   - For refactors, use `moon ide rename`; add `--loc filename:line:col` when names are ambiguous.
+   - Preserve compatibility with `#alias(old_api, deprecated)` when required.
 
-6. **Validate in a tight loop**
+5. **Validate in a tight loop**
    - Run `moon check` after edits, adding `--warn-list +unnecessary_annotation` to enable warning 73 for redundant annotations and over-qualified constructors (`--warn-list +73` is equivalent).
    - Run targeted tests with `moon test [dirname|filename] --filter 'glob'` and use `moon test --update` for snapshot changes.
 
-7. **Finalize before handoff**
+6. **Finalize before handoff**
    - Run `moon fmt`.
    - Run `moon info` to verify whether public APIs changed (`pkg.generated.mbti` diff).
    - Report changed files, validation commands, and any remaining risks.


### PR DESCRIPTION
## Summary

- merge the separate refactoring step into the package-local editing step
- tighten the semantic rename and compatibility guidance
- update four executable examples for the current nightly compiler warnings

## CI fix

The nightly job denies warnings and began rejecting an inexhaustive `guard`, an ambiguous empty-map literal, and deprecated `to_repr(...)` calls. The examples now use an explicit guard failure branch, `Map([])`, and `Repr(...)`.

## Impact

The workflow is slightly shorter, related editing guidance stays together, and all documented `mbt check` examples remain valid on the nightly toolchain.

## Validation

- `moon test moonbit-agent-guide/SKILL.mbt.md --warn-list -1-2-3-6-7-27-28-68 --deny-warn --no-render` — 15 passed
- `git diff --check`
- parsed and verified the skill YAML frontmatter