### PR TITLE
Clarify MoonBit handbook examples

### DIFF
--- a/moonbit-agent-guide/SKILL.md
+++ b/moonbit-agent-guide/SKILL.md
@@ -180,7 +180,7 @@ my_module
 - **Don't write record-style enum or error constructor fields** - labeled constructor fields use `label~ : Type`, e.g. `InvalidNumber(input~ : String)`, not `InvalidNumber(input: String)`
 - **Prefer range `for` loops over C-style** - `for i in 0..<(n-1) {...}` and `for j in 0..=6 {...}` are more idiomatic in MoonBit
 - **Don't use `for { ... }` for infinite loops** - write `for ;; { ... }` instead
-- **Don't `derive(Show)` for debugging** - derive `Debug` and use `debug_inspect()` for test/diagnostic output (`\{to_repr(value)}` for interpolation of composed values). Reserve a manual `impl Show` for specialized display formats (JSON, XML, domain text)
+- **Don't `derive(Show)` for debugging** - derive `Debug` and use `debug_inspect()` for test/diagnostic output (`\{Repr(value)}` for interpolation of composed values). Reserve a manual `impl Show` for specialized display formats (JSON, XML, domain text)
 - **Don't call `@json.inspect()`** - use the prelude `json_inspect(value, ...)` without a package prefix
 - **Async** - MoonBit has no `await` keyword; do not add it. Async functions default to raising, so do not add `raise`; add `noraise` only when the async body must not raise.
   Async functions and tests are characterized by those which call other async functions.
@@ -332,7 +332,7 @@ Public APIs are encouraged to have docstring tests.
 
 ````mbt check
 ///|
-/// Get the largest element of a non-empty `Array`.
+/// Return the sum of an `Array`.
 ///
 /// # Example
 /// ```mbt check
@@ -340,9 +340,6 @@ Public APIs are encouraged to have docstring tests.
 ///   inspect(sum_array([1, 2, 3, 4, 5, 6]), content="21")
 /// }
 /// ```
-///
-/// # Panics
-/// Panics if the `xs` is empty.
 pub fn sum_array(xs : Array[Int]) -> Int {
   xs.fold(init=0, (a, b) => a + b)
 }
@@ -696,7 +693,7 @@ For more advanced topics like `conditional compilation`, `link configuration`, `
 
 Asynchronous programming uses compiler support plus the `moonbitlang/async` runtime. The runtime supports the native backend best, has limited JavaScript support for IO-independent APIs, and does not support WebAssembly yet. For async IO examples, prefer native. Use `moon add moonbitlang/async@<version>` and `moon ide doc "@async"` to explore the API.
 
-User-facing subpackages: `@async` (core: tasks, timers, cancellation), `@async/aqueue`, `@async/fs, `@async/stdio`, `@async/websocket`, ..etc.
+User-facing subpackages include `@async` (tasks, timers, cancellation), `@async/aqueue`, `@async/fs`, `@async/stdio`, and `@async/websocket`.
 Each must be imported separately in `moon.pkg`.
 
 1. Add the dependency and pin the native target in `moon.mod`:
@@ -1069,7 +1066,6 @@ test "map literals and common operations" {
   // Map literal syntax
   let map : Map[String, Int] = { "a": 1, "b": 2, "c": 3 }
   let empty : Map[String, Int] = Map([]) // Empty map
-  let also_empty : Map[String, Int] = Map([])
   // From array of pairs
   let from_pairs : Map[String, Int] = Map::from_array([("x", 1), ("y", 2)])
 


### PR DESCRIPTION
## Summary

- use the current `Repr(value)` spelling in debugging guidance
- align the `sum_array` docstring with its implementation
- fix the async subpackage list formatting
- remove a duplicate empty-map declaration

## Why

These are small correctness and clarity fixes identified during a handbook review. The PR intentionally avoids structural changes so it remains easy to review.

## Validation

- `moon test moonbit-agent-guide/SKILL.mbt.md --warn-list -1-2-3-6-7-27-28-68 --deny-warn --no-render` — 15 passed
- skill validator — passed
- `git diff --check`